### PR TITLE
Issue 111: parent-child retriever

### DIFF
--- a/content-retrievers/langchain4j-community-neo4j-retriever/pom.xml
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/pom.xml
@@ -68,6 +68,18 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-community-neo4j</artifactId>
+            <version>1.0.0-beta3-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+            <version>1.0.0-beta3-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/content-retrievers/langchain4j-community-neo4j-retriever/pom.xml
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/pom.xml
@@ -80,6 +80,13 @@
             <version>1.0.0-beta3-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
+        
+<!--        <dependency>-->
+<!--            <groupId>dev.langchain4j</groupId>-->
+<!--            <artifactId>langchain4j-community-xinference</artifactId>-->
+<!--            <version>${project.version}</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
 
     </dependencies>
 

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/BasicRetriever.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/BasicRetriever.java
@@ -1,0 +1,29 @@
+package dev.langchain4j.rag.content.retriever.neo4j;
+
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import org.neo4j.driver.Driver;
+
+import java.util.Map;
+
+// todo - Neo4jGraph instead of session!!! <-- https://python.langchain.com/docs/integrations/graphs/neo4j_cypher/
+
+// todo - impostazione per query embedding e question, di default query embedding è ugaule a question
+//  TODO : altra classe??? eh a sto punto si...
+        // https://neo4j.com/labs/genai-ecosystem/langchain/#_cypherqachain
+public class BasicRetriever extends Neo4jEmbeddingRetriever {
+
+    public BasicRetriever(final EmbeddingModel embeddingModel, final Driver driver, final int maxResults, final double minScore, final String query, final Map<String, Object> params, final Neo4jEmbeddingStore embeddingStore) {
+        super(embeddingModel, driver, maxResults, minScore, query, params, embeddingStore, null, null, null, null, null);
+    }
+
+    @Override
+    public Neo4jEmbeddingStore getDefaultEmbeddingStore(final Driver driver) {
+        return Neo4jEmbeddingStore.builder()
+                .driver(driver)
+                .dimension(384)
+                .build();
+    }
+    
+    // TODO - test with answerModel
+}

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/HypotheticalQuestionRetriever.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/HypotheticalQuestionRetriever.java
@@ -1,0 +1,65 @@
+package dev.langchain4j.rag.content.retriever.neo4j;
+
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import org.neo4j.driver.Driver;
+
+import java.util.Map;
+
+public class HypotheticalQuestionRetriever extends Neo4jEmbeddingRetriever {
+
+    // TODO - metadata
+    public final static String DEFAULT_RETRIEVAL = """
+            MATCH (node)<-[:HAS_QUESTION]-(parent)
+            WITH parent, max(score) AS score, node // deduplicate parents
+            RETURN parent.text AS text, score, properties(node) AS metadata
+             ORDER BY score DESC
+            LIMIT $maxResults""";
+//            
+//            MATCH (node)<-[:HAS_CHILD]-(parent)
+//            WITH parent, collect(node.text) AS chunks, max(score) AS score
+//            RETURN parent.title + reduce(r = "", c in chunks | r + "\\n\\n" + c) AS text,
+//                   score,
+//                   {source: parent.url} AS metadata
+//            ORDER BY score DESC
+//            LIMIT $maxResults""";
+    public static final String PARENT_QUERY =
+            """
+                        UNWIND $rows AS question
+                        MATCH (p:Parent {parentId: $parentId})
+                        // MERGE (p:Parent {id: $parentId})
+                        WITH p, question
+                        // UNWIND $questions AS question
+                        CREATE (q:%1$s {%2$s: question.%2$s})
+                        SET q += question.%3$s
+                        MERGE (q)<-[:HAS_QUESTION]-(p)
+                        WITH q, question
+                        CALL db.create.setNodeVectorProperty(q, $embeddingProperty, question.%4$s)
+                        // YIELD node
+                        RETURN count(*)
+                    """;
+/*            """
+                UNWIND $rows AS row
+                MATCH (p:Parent {id: $parentId})
+                CREATE (p)-[:HAS_CHILD]->(u:%1$s {%2$s: row.%2$s})
+                SET u += row.%3$s
+                WITH row, u
+                CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.%4$s)
+                RETURN count(*)""";*/
+    
+    public HypotheticalQuestionRetriever(final EmbeddingModel embeddingModel, final Driver driver, final int maxResults, final double minScore, final Neo4jEmbeddingStore embeddingStore) {
+        super(embeddingModel, driver, maxResults, minScore, "CREATE (:Parent $metadata)", Map.of(), embeddingStore);
+    }
+
+    @Override
+    public Neo4jEmbeddingStore getDefaultEmbeddingStore(final Driver driver) {
+        return Neo4jEmbeddingStore.builder()
+                .driver(driver)
+                .retrievalQuery(DEFAULT_RETRIEVAL)
+                .entityCreationQuery(PARENT_QUERY)
+                .label("Child")
+                .indexName("child_embedding_index")
+                .dimension(384)
+                .build();
+    }
+}

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/HypotheticalQuestionRetriever.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/HypotheticalQuestionRetriever.java
@@ -1,6 +1,7 @@
 package dev.langchain4j.rag.content.retriever.neo4j;
 
 import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import org.neo4j.driver.Driver;
 
@@ -46,9 +47,23 @@ public class HypotheticalQuestionRetriever extends Neo4jEmbeddingRetriever {
                 WITH row, u
                 CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.%4$s)
                 RETURN count(*)""";*/
-    
-    public HypotheticalQuestionRetriever(final EmbeddingModel embeddingModel, final Driver driver, final int maxResults, final double minScore, final Neo4jEmbeddingStore embeddingStore) {
-        super(embeddingModel, driver, maxResults, minScore, "CREATE (:Parent $metadata)", Map.of(), embeddingStore);
+
+    public final static String SYSTEM_PROMPT = """
+            You are generating hypothetical questions based on the information found in the text.
+            Make sure to provide full context in the generated questions.
+            """;
+
+    public final static String USER_PROMPT = """
+            Use the given format to generate hypothetical questions from the following input:
+            {{input}}
+            
+            Hypothetical questions:
+            """;
+
+
+
+    public HypotheticalQuestionRetriever(final EmbeddingModel embeddingModel, final Driver driver, final int maxResults, final double minScore, final Neo4jEmbeddingStore embeddingStore, final ChatLanguageModel chatModel, final ChatLanguageModel answerModel, final String promptAnswer) {
+        super(embeddingModel, driver, maxResults, minScore, "CREATE (:Parent $metadata)", Map.of(), embeddingStore, chatModel, SYSTEM_PROMPT, USER_PROMPT, answerModel, promptAnswer);
     }
 
     @Override

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jEmbeddingRetriever.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jEmbeddingRetriever.java
@@ -1,0 +1,61 @@
+package dev.langchain4j.rag.content.retriever.neo4j;
+
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import org.neo4j.driver.Driver;
+
+import java.util.List;
+
+public class Neo4jEmbeddingRetriever implements ContentRetriever {
+    protected final EmbeddingModel embeddingModel;
+    protected final Driver driver;
+    protected final int maxResults;
+    protected final double minScore;
+    protected final Neo4jEmbeddingStore embeddingStore;
+    
+    public Neo4jEmbeddingRetriever(EmbeddingModel embeddingModel, Driver driver,
+                                      int maxResults,
+                                      double minScore, Neo4jEmbeddingStore embeddingStore) {
+        this.embeddingModel = embeddingModel;
+        this.driver = driver;
+        this.maxResults = maxResults;
+        this.minScore = minScore;
+        this.embeddingStore = embeddingStore;
+
+//        if (embeddingStore == null) {
+//            this.embeddingStore = getDefaultEmbeddingStore(driver);
+//        } else {
+//            this.embeddingStore = embeddingStore;
+//        }
+    }
+
+
+    @Override
+    public List<Content> retrieve(final Query query) {
+
+        Embedding queryEmbedding = embeddingModel.embed(query.text()).content();
+
+
+        final EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .maxResults(maxResults)
+                .minScore(minScore)
+                .build();
+
+        return embeddingStore.search(request)
+                .matches()
+                .stream()
+                .map(i -> {
+                    final TextSegment embedded = i.embedded();
+                    return Content.from(embedded);
+                })
+                .toList();
+    }
+
+}

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jEmbeddingRetriever.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jEmbeddingRetriever.java
@@ -1,6 +1,9 @@
 package dev.langchain4j.rag.content.retriever.neo4j;
 
 import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
@@ -9,30 +12,166 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.rag.query.Query;
 import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import org.neo4j.driver.Driver;
+import org.neo4j.driver.Session;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-public class Neo4jEmbeddingRetriever implements ContentRetriever {
+import static dev.langchain4j.internal.Utils.getOrDefault;
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
+/*
+TODO: fare qualcosa di simile a questo... MAGARI SOLO UN TEST?
+# flake8: noqa
+from langchain_core.prompts.prompt import PromptTemplate
+
+_template = """Given the following conversation and a follow up question, rephrase the follow up question to be a standalone question.
+
+Chat History:
+{chat_history}
+Follow Up Input: {question}
+Standalone question:"""
+CONDENSE_QUESTION_PROMPT = PromptTemplate.from_template(_template)
+
+prompt_template = """Use the following pieces of context to answer the question at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+
+{context}
+
+Question: {question}
+Helpful Answer:"""
+QA_PROMPT = PromptTemplate(
+    template=prompt_template, input_variables=["context", "question"]
+)
+
+ */
+
+
+
+// TODO - customizzarlo simile a https://python.langchain.com/v0.1/docs/modules/data_connection/retrievers/custom_retriever/
+    //   con (...DocumentSplitter parentSplitter)
+public abstract class Neo4jEmbeddingRetriever implements ContentRetriever {
     protected final EmbeddingModel embeddingModel;
     protected final Driver driver;
-    protected final int maxResults;
-    protected final double minScore;
+    protected final Integer maxResults;
+    protected final Double minScore;
     protected final Neo4jEmbeddingStore embeddingStore;
-    
-    public Neo4jEmbeddingRetriever(EmbeddingModel embeddingModel, Driver driver,
-                                      int maxResults,
-                                      double minScore, Neo4jEmbeddingStore embeddingStore) {
+    protected final String query;
+    protected final Map<String, Object> params;
+
+    /**
+     * // TODO --> EmbeddingSearchRequest javadoc
+     * 
+     * @param embeddingModel
+     * @param driver
+     * @param maxResults
+     * @param minScore
+     * @param embeddingStore
+     */
+    public Neo4jEmbeddingRetriever(EmbeddingModel embeddingModel, 
+                                   Driver driver,
+                                   int maxResults,
+                                   double minScore, 
+                                   String query,
+                                   Map<String, Object> params,
+                                   Neo4jEmbeddingStore embeddingStore) {
         this.embeddingModel = embeddingModel;
         this.driver = driver;
         this.maxResults = maxResults;
         this.minScore = minScore;
-        this.embeddingStore = embeddingStore;
+        this.query = query;
+        this.params = params;
+        final Neo4jEmbeddingStore store = getOrDefault(embeddingStore, getDefaultEmbeddingStore(driver));
 
-//        if (embeddingStore == null) {
-//            this.embeddingStore = getDefaultEmbeddingStore(driver);
-//        } else {
-//            this.embeddingStore = embeddingStore;
-//        }
+        this.embeddingStore = ensureNotNull(store, "embeddingStore");
+    }
+    
+    public Neo4jEmbeddingStore getDefaultEmbeddingStore(Driver driver) {
+        return null;
+    }
+
+    public void index(Document document,
+                      DocumentSplitter parentSplitter,
+                      DocumentSplitter childSplitter) {
+
+        List<TextSegment> parentSegments = parentSplitter.split(document);
+
+            for (int i = 0; i < parentSegments.size(); i++) {
+                TextSegment parentSegment = parentSegments.get(i);
+                String parentId = "parent_" + i;
+
+                // Store parent node
+                final Metadata metadata = document.metadata();
+                
+                final String parentIdKey = "parentId";
+                if (this.query != null) {
+                    final Map<String, Object> metadataMap = metadata.toMap();
+                    metadataMap.put(parentIdKey, parentId);
+                    metadataMap.putIfAbsent("text", parentSegment.text());
+                    metadataMap.putIfAbsent("title", "Untitled");
+                    final Map<String, Object> params = Map.of("metadata", metadataMap);
+                    metadataMap.putAll(this.params);
+                    try (Session session = driver.session()) {
+                        session.run(this.query, params);
+                    }
+                }
+
+                // Convert back to Document to apply DocumentSplitter
+                Document parentDoc = Document.from(parentSegment.text(), metadata);
+
+                if (childSplitter == null) {
+                    final Embedding content = embeddingModel.embed(parentSegment).content();
+                    getAdditionalParams(parentIdKey, parentId);
+                    embeddingStore.add(content, parentSegment);
+                    return;
+                }
+
+                final String idProperty = embeddingStore.getIdProperty();
+                List<TextSegment> childSegments = childSplitter.split(parentDoc)
+                        .stream()
+                        .map(segment -> getTextSegment(segment, idProperty, parentId))
+                        .toList();
+
+                final List<Embedding> embeddings = embeddingModel.embedAll(childSegments).content();
+                getAdditionalParams(parentIdKey, parentId);
+                embeddingStore.addAll(embeddings, childSegments);
+        }
+    }
+
+    private void getAdditionalParams(String parentIdKey, String parentId) {
+        final HashMap<String, Object> params = new HashMap<>(this.params);
+        params.put(parentIdKey, parentId);
+        embeddingStore.setAdditionalParams(params);
+    }
+//
+//    public void getDocumentToNeo4jQuery(Session session, Map<String, Object> params) {
+//        session.run(getQuery(), getParams(params));
+//    }
+//
+//    private static Map<String, Object> getParams(Map<String, Object> params) {
+//        return params;
+//    }
+//
+//    private static String getQuery() {
+//        return """
+//                    CREATE (:Parent $metadata)
+//                """;
+//    }
+
+
+    // TODO --> 
+    //  if `id` metadata is present, we create a new univoc one to prentent this error:
+    //  org.neo4j.driver.exceptions.ClientException: Node(1) already exists with label `Child` and property `id` = 'doc-ai'
+    public TextSegment getTextSegment(TextSegment segment, String idProperty, String parentId) {
+        final Metadata metadata1 = segment.metadata();
+        final Object idMeta = metadata1.toMap().get(idProperty);
+        String value = parentId + idMeta;
+        if (idMeta != null) {
+            value += "_" + idMeta;
+        }
+        metadata1.put(idProperty, value);
+
+        return segment;
     }
 
 
@@ -40,8 +179,7 @@ public class Neo4jEmbeddingRetriever implements ContentRetriever {
     public List<Content> retrieve(final Query query) {
 
         Embedding queryEmbedding = embeddingModel.embed(query.text()).content();
-
-
+        
         final EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
                 .queryEmbedding(queryEmbedding)
                 .maxResults(maxResults)
@@ -57,5 +195,5 @@ public class Neo4jEmbeddingRetriever implements ContentRetriever {
                 })
                 .toList();
     }
-
+    
 }

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jGraph.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jGraph.java
@@ -56,7 +56,7 @@ public class Neo4jGraph implements AutoCloseable {
                     RETURN {start: label, type: property, end: toString(other_node)} AS output
                     """;
 
-    private final Driver driver;
+    public final Driver driver;
 
     private String schema;
 

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever2.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever2.java
@@ -7,23 +7,11 @@ import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
-import dev.langchain4j.model.output.Response;
-import dev.langchain4j.rag.content.Content;
-import dev.langchain4j.rag.content.retriever.ContentRetriever;
-import dev.langchain4j.rag.query.Query;
-import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import org.neo4j.driver.Driver;
-import org.neo4j.driver.Record;
-import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-
-import static dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore.CREATE_VECTOR_INDEX;
-import static dev.langchain4j.internal.Utils.randomUUID;
 
 public class ParentChildGraphRetriever2 extends Neo4jEmbeddingRetriever {
     public final static String DEFAULT_RETRIEVAL = """
@@ -34,42 +22,41 @@ public class ParentChildGraphRetriever2 extends Neo4jEmbeddingRetriever {
                    {source: parent.url} AS metadata
             ORDER BY score DESC
             LIMIT $maxResults""";
+
     public static final String PARENT_QUERY =
 
             """
                 UNWIND $rows AS row
-                MATCH (p:Parent {id: $parentId})
+                MATCH (p:Parent {parentId: $parentId})
                 CREATE (p)-[:HAS_CHILD]->(u:%1$s {%2$s: row.%2$s})
                 SET u += row.%3$s
                 WITH row, u
                 CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.%4$s)
                 RETURN count(*)""";
-
-//    private final EmbeddingModel embeddingModel;
-//    private final Driver driver;
-//    private final int maxResults;
-//    private final double minScore;
-//    private final Neo4jEmbeddingStore embeddingStore;
     
 
+    // TODO https://chatgpt.com/c/67ff6a72-5fe0-800c-9c12-c50ec8d5ee35
+    // todo --> creare un fromLLM
+    
     public ParentChildGraphRetriever2(EmbeddingModel embeddingModel, Driver driver,
                                       int maxResults,
                                       double minScore, Neo4jEmbeddingStore embeddingStore) {
-        super(embeddingModel, driver, maxResults, minScore, embeddingStore);
+        super(embeddingModel, driver, maxResults, minScore, "CREATE (:Parent $metadata)", Map.of(), embeddingStore);
 //        this.embeddingModel = embeddingModel;
 //        this.driver = driver;
 //        this.maxResults = maxResults;
 //        this.minScore = minScore;
         
-        if (embeddingStore == null) {
-            this.embeddingStore = getDefaultEmbeddingStore(driver);
-        }
+//        if (embeddingStore == null) {
+//            this.embeddingStore = getDefaultEmbeddingStore(driver);
+//        }
 //        else {
 //            this.embeddingStore = embeddingStore;
 //        }
     }
 
-    private static Neo4jEmbeddingStore getDefaultEmbeddingStore(Driver driver) {
+    @Override
+    public Neo4jEmbeddingStore getDefaultEmbeddingStore(Driver driver) {
         return Neo4jEmbeddingStore.builder()
                 .driver(driver)
                 .retrievalQuery(DEFAULT_RETRIEVAL)
@@ -80,113 +67,14 @@ public class ParentChildGraphRetriever2 extends Neo4jEmbeddingRetriever {
                 .build();
     }
 
-    public void index(Document document,
-                      DocumentSplitter parentSplitter,
-                      DocumentSplitter childSplitter) {
-
-        List<TextSegment> parentSegments = parentSplitter.split(document);
-
-        try (Session session = driver.session()) {
-            for (int i = 0; i < parentSegments.size(); i++) {
-                TextSegment parentSegment = parentSegments.get(i);
-                String parentId = "parent_" + i;
-
-                // Store parent node
-                final Metadata metadata = document.metadata();
-                final Map<String, Object> metadataMap = metadata.toMap();
-                session.run("""
-                CREATE (:Parent {
-                    id: $id,
-                    title: $title,
-                    url: $url,
-                    text: $text
-                })
-            """, Map.of(
-                        "id", parentId,
-                        "title", metadataMap.getOrDefault("title", "Untitled"),
-                        "url", metadataMap.getOrDefault("url", ""),
-                        "text", parentSegment.text()
-                ));
-
-                // Convert back to Document to apply DocumentSplitter
-                Document parentDoc = Document.from(parentSegment.text(), metadata);
-
-                
-                
-                final String idProperty = embeddingStore.getIdProperty();
-                List<TextSegment> childSegments = childSplitter.split(parentDoc)
-                        .stream()
-                        .map(segment -> {
-                            return getTextSegment(segment, idProperty, parentId);
-                        })
-                        .toList();
-
-                final List<Embedding> embeddings = embeddingModel.embedAll(childSegments).content();
-                embeddingStore.setAdditionalParams(Map.of("parentId", parentId));
-                embeddingStore.addAll(embeddings, childSegments);
-            }
-        }
-
-        // create vector index
-        try (var session = driver.session()) {
-
-//            Map<String, Object> params = Map.of(
-//                    "indexName",
-//                    vectorIndex,
-//                    "label",
-//                    this.label,
-//                    "embeddingProperty",
-//                    this.embeddingProperty,
-//                    "dimension",
-//                    this.dimension);
-            
-            final String createIndexQuery = String.format(
-                    CREATE_VECTOR_INDEX, embeddingStore.getIndexName(), 
-                    embeddingStore.getSanitizedLabel(), embeddingStore.getSanitizedEmbeddingProperty(), embeddingStore.getDimension());
-//                    CREATE_VECTOR_INDEX, vectorIndex, "Child", "embedding", embeddingDimension);
-            session.run(createIndexQuery);
-
-            session.run("CALL db.awaitIndexes($timeout)", Map.of("timeout", 20000))
-                    .consume();
-        }
-    }
-
-    // TODO --> 
-    //  if `id` metadata is present, we create a new univoc one to prentent this error:
-    //  org.neo4j.driver.exceptions.ClientException: Node(1) already exists with label `Child` and property `id` = 'doc-ai'
-    private static TextSegment getTextSegment(TextSegment segment, String idProperty, String parentId) {
-        final Metadata metadata1 = segment.metadata();
-        final Object idMeta = metadata1.toMap().get(idProperty);
-        String value = parentId + idMeta;
-        if (idMeta != null) {
-            value += "_" + idMeta;
-        }
-        metadata1.put(idProperty, value);
-
-        return segment;
-    }
 
 
 //    @Override
-//    public List<Content> retrieve(final Query query) {
-//        
-//        Embedding queryEmbedding = embeddingModel.embed(query.text()).content();
-//
-//
-//        final EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
-//                .queryEmbedding(queryEmbedding)
-//                .maxResults(maxResults)
-//                .minScore(minScore)
-//                .build();
-//
-//        return embeddingStore.search(request)
-//                .matches()
-//                .stream()
-//                .map(i -> {
-//                    final TextSegment embedded = i.embedded();
-//                    return Content.from(embedded);
-//                })
-//                .toList();
+//    public void getDocumentToNeo4jQuery(Session session, Map<String, Object> params) {
+//        session.run("""
+//            CREATE (:Parent $metadata)
+//        """, params);
 //    }
+
 
 }

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever2.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever2.java
@@ -17,9 +17,9 @@ public class ParentChildGraphRetriever2 extends Neo4jEmbeddingRetriever {
     public final static String DEFAULT_RETRIEVAL = """
             MATCH (node)<-[:HAS_CHILD]-(parent)
             WITH parent, collect(node.text) AS chunks, max(score) AS score
-            RETURN parent.title + reduce(r = "", c in chunks | r + "\\n\\n" + c) AS text,
+            RETURN parent.text + reduce(r = "", c in chunks | r + "\\n\\n" + c) AS text,
                    score,
-                   {source: parent.url} AS metadata
+                   properties(parent) AS metadata
             ORDER BY score DESC
             LIMIT $maxResults""";
 
@@ -33,15 +33,12 @@ public class ParentChildGraphRetriever2 extends Neo4jEmbeddingRetriever {
                 WITH row, u
                 CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.%4$s)
                 RETURN count(*)""";
-    
 
-    // TODO https://chatgpt.com/c/67ff6a72-5fe0-800c-9c12-c50ec8d5ee35
-    // todo --> creare un fromLLM
     
     public ParentChildGraphRetriever2(EmbeddingModel embeddingModel, Driver driver,
                                       int maxResults,
                                       double minScore, Neo4jEmbeddingStore embeddingStore) {
-        super(embeddingModel, driver, maxResults, minScore, "CREATE (:Parent $metadata)", Map.of(), embeddingStore);
+        super(embeddingModel, driver, maxResults, minScore, "CREATE (:Parent $metadata)", Map.of(), embeddingStore,  null, null, null, null, null);
 //        this.embeddingModel = embeddingModel;
 //        this.driver = driver;
 //        this.maxResults = maxResults;

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever2.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever2.java
@@ -1,43 +1,85 @@
 package dev.langchain4j.rag.content.retriever.neo4j;
 
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
 import dev.langchain4j.data.document.Document;
 import dev.langchain4j.data.document.DocumentSplitter;
 import dev.langchain4j.data.document.Metadata;
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.output.Response;
 import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.Value;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore.CREATE_VECTOR_INDEX;
+import static dev.langchain4j.internal.Utils.randomUUID;
 
-// TODO - salvare con addDocument e splitters
-// retriever simile a text to cypher, parent_document_retrieval
+public class ParentChildGraphRetriever2 extends Neo4jEmbeddingRetriever {
+    public final static String DEFAULT_RETRIEVAL = """
+            MATCH (node)<-[:HAS_CHILD]-(parent)
+            WITH parent, collect(node.text) AS chunks, max(score) AS score
+            RETURN parent.title + reduce(r = "", c in chunks | r + "\\n\\n" + c) AS text,
+                   score,
+                   {source: parent.url} AS metadata
+            ORDER BY score DESC
+            LIMIT $maxResults""";
+    public static final String PARENT_QUERY =
 
-public class ParentChildGraphRetriever2 {
+            """
+                UNWIND $rows AS row
+                MATCH (p:Parent {id: $parentId})
+                CREATE (p)-[:HAS_CHILD]->(u:%1$s {%2$s: row.%2$s})
+                SET u += row.%3$s
+                WITH row, u
+                CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.%4$s)
+                RETURN count(*)""";
 
-    private final EmbeddingModel embeddingModel;
-    private final Driver driver;
-    private final String vectorIndex;
-    private final int embeddingDimension;
+//    private final EmbeddingModel embeddingModel;
+//    private final Driver driver;
+//    private final int maxResults;
+//    private final double minScore;
+//    private final Neo4jEmbeddingStore embeddingStore;
+    
 
     public ParentChildGraphRetriever2(EmbeddingModel embeddingModel, Driver driver,
-                                     String vectorIndex, int embeddingDimension) {
-        this.embeddingModel = embeddingModel;
-        this.driver = driver;
-        this.vectorIndex = vectorIndex;
-        this.embeddingDimension = embeddingDimension;
+                                      int maxResults,
+                                      double minScore, Neo4jEmbeddingStore embeddingStore) {
+        super(embeddingModel, driver, maxResults, minScore, embeddingStore);
+//        this.embeddingModel = embeddingModel;
+//        this.driver = driver;
+//        this.maxResults = maxResults;
+//        this.minScore = minScore;
+        
+        if (embeddingStore == null) {
+            this.embeddingStore = getDefaultEmbeddingStore(driver);
+        }
+//        else {
+//            this.embeddingStore = embeddingStore;
+//        }
     }
 
-    // TODO - salvare con addDocument e splitters
+    private static Neo4jEmbeddingStore getDefaultEmbeddingStore(Driver driver) {
+        return Neo4jEmbeddingStore.builder()
+                .driver(driver)
+                .retrievalQuery(DEFAULT_RETRIEVAL)
+                .entityCreationQuery(PARENT_QUERY)
+                .label("Child")
+                .indexName("child_embedding_index")
+                .dimension(384)
+                .build();
+    }
+
     public void index(Document document,
                       DocumentSplitter parentSplitter,
                       DocumentSplitter childSplitter) {
@@ -47,7 +89,7 @@ public class ParentChildGraphRetriever2 {
         try (Session session = driver.session()) {
             for (int i = 0; i < parentSegments.size(); i++) {
                 TextSegment parentSegment = parentSegments.get(i);
-                String parentId = /*document.id() +*/ "_p" + i;
+                String parentId = "parent_" + i;
 
                 // Store parent node
                 final Metadata metadata = document.metadata();
@@ -69,29 +111,19 @@ public class ParentChildGraphRetriever2 {
                 // Convert back to Document to apply DocumentSplitter
                 Document parentDoc = Document.from(parentSegment.text(), metadata);
 
-                List<TextSegment> childSegments = childSplitter.split(parentDoc);
+                
+                
+                final String idProperty = embeddingStore.getIdProperty();
+                List<TextSegment> childSegments = childSplitter.split(parentDoc)
+                        .stream()
+                        .map(segment -> {
+                            return getTextSegment(segment, idProperty, parentId);
+                        })
+                        .toList();
 
-                for (int j = 0; j < childSegments.size(); j++) {
-                    TextSegment childSegment = childSegments.get(j);
-                    String childId = parentId + "_c" + j;
-
-                    Embedding embedding = embeddingModel.embed(childSegment).content();
-
-                    // Store child node and link to parent
-                    session.run("""
-                    MATCH (p:Parent {id: $parentId})
-                    CREATE (p)-[:HAS_CHILD]->(:Child {
-                        id: $childId,
-                        text: $text,
-                        embedding: $embedding
-                    })
-                """, Map.of(
-                            "parentId", parentId,
-                            "childId", childId,
-                            "text", childSegment.text(),
-                            "embedding", embedding.vector()
-                    ));
-                }
+                final List<Embedding> embeddings = embeddingModel.embedAll(childSegments).content();
+                embeddingStore.setAdditionalParams(Map.of("parentId", parentId));
+                embeddingStore.addAll(embeddings, childSegments);
             }
         }
 
@@ -109,7 +141,9 @@ public class ParentChildGraphRetriever2 {
 //                    this.dimension);
             
             final String createIndexQuery = String.format(
-                    CREATE_VECTOR_INDEX, vectorIndex, "Child", "embedding", embeddingDimension);
+                    CREATE_VECTOR_INDEX, embeddingStore.getIndexName(), 
+                    embeddingStore.getSanitizedLabel(), embeddingStore.getSanitizedEmbeddingProperty(), embeddingStore.getDimension());
+//                    CREATE_VECTOR_INDEX, vectorIndex, "Child", "embedding", embeddingDimension);
             session.run(createIndexQuery);
 
             session.run("CALL db.awaitIndexes($timeout)", Map.of("timeout", 20000))
@@ -117,44 +151,42 @@ public class ParentChildGraphRetriever2 {
         }
     }
 
-
-
-    public List<Content> retrieve(String query, int topK, double minScore) {
-        Embedding queryEmbedding = embeddingModel.embed(TextSegment.from(query)).content();
-
-        // TODO - embeddingStore con retrievalQuery diversa?
-        try (Session session = driver.session()) {
-            Result result = session.run("""
-            CALL db.index.vector.queryNodes($index, $k, $embedding)
-            YIELD node AS child, score
-            WHERE score >= $minScore
-            MATCH (child)<-[:HAS_CHILD]-(parent)
-            WITH parent, collect(child.text) AS chunks, max(score) AS score
-            RETURN parent.title + reduce(r = "", c in chunks | r + "\\n\\n" + c) AS text,
-                   score,
-                   {source: parent.url} AS metadata
-            ORDER BY score DESC
-            LIMIT $k
-        """, Map.of(
-                    "index", vectorIndex,
-                    "k", topK,
-                    "embedding", queryEmbedding.vector(),
-                    "minScore", minScore
-            ));
-
-            List<Content> results = new ArrayList<>();
-            while (result.hasNext()) {
-                Record record = result.next();
-                String mergedText = record.get("text").asString();
-                final Map<String, Object> metadata = record.get("metadata").asMap();
-
-                results.add(Content.from(
-                        TextSegment.from(mergedText, Metadata.from(metadata))//.withMetadata(metadata.asMap(Function.identity()))
-                ));
-            }
-
-            return results;
+    // TODO --> 
+    //  if `id` metadata is present, we create a new univoc one to prentent this error:
+    //  org.neo4j.driver.exceptions.ClientException: Node(1) already exists with label `Child` and property `id` = 'doc-ai'
+    private static TextSegment getTextSegment(TextSegment segment, String idProperty, String parentId) {
+        final Metadata metadata1 = segment.metadata();
+        final Object idMeta = metadata1.toMap().get(idProperty);
+        String value = parentId + idMeta;
+        if (idMeta != null) {
+            value += "_" + idMeta;
         }
+        metadata1.put(idProperty, value);
+
+        return segment;
     }
+
+
+//    @Override
+//    public List<Content> retrieve(final Query query) {
+//        
+//        Embedding queryEmbedding = embeddingModel.embed(query.text()).content();
+//
+//
+//        final EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+//                .queryEmbedding(queryEmbedding)
+//                .maxResults(maxResults)
+//                .minScore(minScore)
+//                .build();
+//
+//        return embeddingStore.search(request)
+//                .matches()
+//                .stream()
+//                .map(i -> {
+//                    final TextSegment embedded = i.embedded();
+//                    return Content.from(embedded);
+//                })
+//                .toList();
+//    }
 
 }

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever2.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever2.java
@@ -1,0 +1,160 @@
+package dev.langchain4j.rag.content.retriever.neo4j;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.rag.content.Content;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore.CREATE_VECTOR_INDEX;
+
+// TODO - salvare con addDocument e splitters
+// retriever simile a text to cypher, parent_document_retrieval
+
+public class ParentChildGraphRetriever2 {
+
+    private final EmbeddingModel embeddingModel;
+    private final Driver driver;
+    private final String vectorIndex;
+    private final int embeddingDimension;
+
+    public ParentChildGraphRetriever2(EmbeddingModel embeddingModel, Driver driver,
+                                     String vectorIndex, int embeddingDimension) {
+        this.embeddingModel = embeddingModel;
+        this.driver = driver;
+        this.vectorIndex = vectorIndex;
+        this.embeddingDimension = embeddingDimension;
+    }
+
+    // TODO - salvare con addDocument e splitters
+    public void index(Document document,
+                      DocumentSplitter parentSplitter,
+                      DocumentSplitter childSplitter) {
+
+        List<TextSegment> parentSegments = parentSplitter.split(document);
+
+        try (Session session = driver.session()) {
+            for (int i = 0; i < parentSegments.size(); i++) {
+                TextSegment parentSegment = parentSegments.get(i);
+                String parentId = /*document.id() +*/ "_p" + i;
+
+                // Store parent node
+                final Metadata metadata = document.metadata();
+                final Map<String, Object> metadataMap = metadata.toMap();
+                session.run("""
+                CREATE (:Parent {
+                    id: $id,
+                    title: $title,
+                    url: $url,
+                    text: $text
+                })
+            """, Map.of(
+                        "id", parentId,
+                        "title", metadataMap.getOrDefault("title", "Untitled"),
+                        "url", metadataMap.getOrDefault("url", ""),
+                        "text", parentSegment.text()
+                ));
+
+                // Convert back to Document to apply DocumentSplitter
+                Document parentDoc = Document.from(parentSegment.text(), metadata);
+
+                List<TextSegment> childSegments = childSplitter.split(parentDoc);
+
+                for (int j = 0; j < childSegments.size(); j++) {
+                    TextSegment childSegment = childSegments.get(j);
+                    String childId = parentId + "_c" + j;
+
+                    Embedding embedding = embeddingModel.embed(childSegment).content();
+
+                    // Store child node and link to parent
+                    session.run("""
+                    MATCH (p:Parent {id: $parentId})
+                    CREATE (p)-[:HAS_CHILD]->(:Child {
+                        id: $childId,
+                        text: $text,
+                        embedding: $embedding
+                    })
+                """, Map.of(
+                            "parentId", parentId,
+                            "childId", childId,
+                            "text", childSegment.text(),
+                            "embedding", embedding.vector()
+                    ));
+                }
+            }
+        }
+
+        // create vector index
+        try (var session = driver.session()) {
+
+//            Map<String, Object> params = Map.of(
+//                    "indexName",
+//                    vectorIndex,
+//                    "label",
+//                    this.label,
+//                    "embeddingProperty",
+//                    this.embeddingProperty,
+//                    "dimension",
+//                    this.dimension);
+            
+            final String createIndexQuery = String.format(
+                    CREATE_VECTOR_INDEX, vectorIndex, "Child", "embedding", embeddingDimension);
+            session.run(createIndexQuery);
+
+            session.run("CALL db.awaitIndexes($timeout)", Map.of("timeout", 20000))
+                    .consume();
+        }
+    }
+
+
+
+    public List<Content> retrieve(String query, int topK, double minScore) {
+        Embedding queryEmbedding = embeddingModel.embed(TextSegment.from(query)).content();
+
+        // TODO - embeddingStore con retrievalQuery diversa?
+        try (Session session = driver.session()) {
+            Result result = session.run("""
+            CALL db.index.vector.queryNodes($index, $k, $embedding)
+            YIELD node AS child, score
+            WHERE score >= $minScore
+            MATCH (child)<-[:HAS_CHILD]-(parent)
+            WITH parent, collect(child.text) AS chunks, max(score) AS score
+            RETURN parent.title + reduce(r = "", c in chunks | r + "\\n\\n" + c) AS text,
+                   score,
+                   {source: parent.url} AS metadata
+            ORDER BY score DESC
+            LIMIT $k
+        """, Map.of(
+                    "index", vectorIndex,
+                    "k", topK,
+                    "embedding", queryEmbedding.vector(),
+                    "minScore", minScore
+            ));
+
+            List<Content> results = new ArrayList<>();
+            while (result.hasNext()) {
+                Record record = result.next();
+                String mergedText = record.get("text").asString();
+                final Map<String, Object> metadata = record.get("metadata").asMap();
+
+                results.add(Content.from(
+                        TextSegment.from(mergedText, Metadata.from(metadata))//.withMetadata(metadata.asMap(Function.identity()))
+                ));
+            }
+
+            return results;
+        }
+    }
+
+}

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever22.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever22.java
@@ -1,0 +1,159 @@
+package dev.langchain4j.rag.content.retriever.neo4j;
+
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.rag.content.Content;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore.CREATE_VECTOR_INDEX;
+
+// TODO - salvare con addDocument e splitters
+// retriever simile a text to cypher, parent_document_retrieval
+
+public class ParentChildGraphRetriever22 {
+
+    private final EmbeddingModel embeddingModel;
+    private final Driver driver;
+    private final String vectorIndex;
+    private final int embeddingDimension;
+
+    public ParentChildGraphRetriever22(EmbeddingModel embeddingModel, Driver driver,
+                                       String vectorIndex, int embeddingDimension) {
+        this.embeddingModel = embeddingModel;
+        this.driver = driver;
+        this.vectorIndex = vectorIndex;
+        this.embeddingDimension = embeddingDimension;
+    }
+
+    // TODO - salvare con addDocument e splitters
+    public void index(Document document,
+                      DocumentSplitter parentSplitter,
+                      DocumentSplitter childSplitter) {
+
+        List<TextSegment> parentSegments = parentSplitter.split(document);
+
+        try (Session session = driver.session()) {
+            for (int i = 0; i < parentSegments.size(); i++) {
+                TextSegment parentSegment = parentSegments.get(i);
+                String parentId = "_p" + i;
+
+                // Store parent node
+                final Metadata metadata = document.metadata();
+                final Map<String, Object> metadataMap = metadata.toMap();
+                session.run("""
+                CREATE (:Parent {
+                    id: $id,
+                    title: $title,
+                    url: $url,
+                    text: $text
+                })
+            """, Map.of(
+                        "id", parentId,
+                        "title", metadataMap.getOrDefault("title", "Untitled"),
+                        "url", metadataMap.getOrDefault("url", ""),
+                        "text", parentSegment.text()
+                ));
+
+                // Convert back to Document to apply DocumentSplitter
+                Document parentDoc = Document.from(parentSegment.text(), metadata);
+
+                List<TextSegment> childSegments = childSplitter.split(parentDoc);
+
+                for (int j = 0; j < childSegments.size(); j++) {
+                    TextSegment childSegment = childSegments.get(j);
+                    String childId = parentId + "_c" + j;
+
+                    Embedding embedding = embeddingModel.embed(childSegment).content();
+
+                    // Store child node and link to parent
+                    session.run("""
+                    MATCH (p:Parent {id: $parentId})
+                    CREATE (p)-[:HAS_CHILD]->(:Child {
+                        id: $childId,
+                        text: $text,
+                        embedding: $embedding
+                    })
+                """, Map.of(
+                            "parentId", parentId,
+                            "childId", childId,
+                            "text", childSegment.text(),
+                            "embedding", embedding.vector()
+                    ));
+                }
+            }
+        }
+
+        // create vector index
+        try (var session = driver.session()) {
+
+//            Map<String, Object> params = Map.of(
+//                    "indexName",
+//                    vectorIndex,
+//                    "label",
+//                    this.label,
+//                    "embeddingProperty",
+//                    this.embeddingProperty,
+//                    "dimension",
+//                    this.dimension);
+            
+            final String createIndexQuery = String.format(
+                    CREATE_VECTOR_INDEX, vectorIndex, "Child", "embedding", embeddingDimension);
+            session.run(createIndexQuery);
+
+            session.run("CALL db.awaitIndexes($timeout)", Map.of("timeout", 20000))
+                    .consume();
+        }
+    }
+
+
+
+    public List<Content> retrieve(String query, int topK, double minScore) {
+        Embedding queryEmbedding = embeddingModel.embed(TextSegment.from(query)).content();
+
+        // TODO - embeddingStore con retrievalQuery diversa?
+        try (Session session = driver.session()) {
+            Result result = session.run("""
+            CALL db.index.vector.queryNodes($index, $k, $embedding)
+            YIELD node AS child, score
+            WHERE score >= $minScore
+            MATCH (child)<-[:HAS_CHILD]-(parent)
+            WITH parent, collect(child.text) AS chunks, max(score) AS score
+            RETURN parent.title + reduce(r = "", c in chunks | r + "\\n\\n" + c) AS text,
+                   score,
+                   {source: parent.url} AS metadata
+            ORDER BY score DESC
+            LIMIT $k
+        """, Map.of(
+                    "index", vectorIndex,
+                    "k", topK,
+                    "embedding", queryEmbedding.vector(),
+                    "minScore", minScore
+            ));
+
+            List<Content> results = new ArrayList<>();
+            while (result.hasNext()) {
+                Record record = result.next();
+                String mergedText = record.get("text").asString();
+                final Map<String, Object> metadata = record.get("metadata").asMap();
+
+                results.add(Content.from(
+                        TextSegment.from(mergedText, Metadata.from(metadata))//.withMetadata(metadata.asMap(Function.identity()))
+                ));
+            }
+
+            return results;
+        }
+    }
+
+}

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever23.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildGraphRetriever23.java
@@ -1,0 +1,250 @@
+package dev.langchain4j.rag.content.retriever.neo4j;
+
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Query;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore.CREATE_VECTOR_INDEX;
+
+// TODO - salvare con addDocument e splitters
+// TODO - create un generic retriever???
+
+// retriever simile a text to cypher, parent_document_retrieval
+
+public class ParentChildGraphRetriever23 implements ContentRetriever {
+    public final static String DEFAULT_RETRIEVAL = """
+            MATCH (child)<-[:HAS_CHILD]-(parent)
+            WITH parent, collect(child.text) AS chunks, max(score) AS score
+            RETURN parent.title + reduce(r = "", c in chunks | r + "\\n\\n" + c) AS text,
+                   score,
+                   {source: parent.url} AS metadata
+            ORDER BY score DESC
+            LIMIT $k""";
+
+    public static final String PARENT_QUERY =
+//            """
+//                    UNWIND $rows AS row
+//                    MERGE (u:%1$s {%2$s: row.%2$s})
+//                    SET u += row.%3$s
+//                    WITH row, u
+//                    CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.%4$s)
+//                    RETURN count(*)""";
+            
+            """
+                UNWIND $rows AS row
+                MATCH (p:Parent {id: $parentId})
+                CREATE (p)-[:HAS_CHILD]->(u:%1$s {%2$s: row.%2$s})
+                SET u += row.%3$s
+                WITH row, u
+                CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.%4$s)
+                RETURN count(*)""";
+                
+//                """
+//                MATCH (p:Parent {id: $parentId})
+//                CREATE (p)-[:HAS_CHILD]->(:Child {
+//                    id: $childId,
+//                    text: $text,
+//                    embedding: $embedding
+//                })
+//            """;
+
+    private final EmbeddingModel embeddingModel;
+    private final Driver driver;
+//    private final String vectorIndex;
+//    private final int embeddingDimension;
+    private final int maxResults;
+    private final double minScore;
+    private final Neo4jEmbeddingStore embeddingStore;
+    
+
+    public ParentChildGraphRetriever23(EmbeddingModel embeddingModel, Driver driver,
+                                       //  String vectorIndex,// int embeddingDimension,
+                                       int maxResults,
+                                       double minScore, Neo4jEmbeddingStore embeddingStore) {
+//        this.embeddingStore = embeddingStore;
+        this.embeddingModel = embeddingModel;
+        this.driver = driver;
+//        this.vectorIndex = vectorIndex;
+//        this.embeddingDimension = embeddingDimension;
+        this.maxResults = maxResults;
+        this.minScore = minScore;
+        
+        if (embeddingStore == null) {
+            this.embeddingStore = Neo4jEmbeddingStore.builder()
+                    .driver(driver)
+                    .retrievalQuery(DEFAULT_RETRIEVAL)
+                    .entityCreationQuery(PARENT_QUERY)
+                    .label("Child")
+                    .indexName("child_embedding_index")
+                    .dimension(384)
+                    .build();
+        } else {
+            this.embeddingStore = embeddingStore;
+        }
+//        embeddingStore.setRetrievalQuery(DEFAULT_RETRIEVAL);
+    }
+
+    // TODO - salvare con addDocument e splitters
+    public void index(Document document,
+                      DocumentSplitter parentSplitter,
+                      DocumentSplitter childSplitter) {
+
+        List<TextSegment> parentSegments = parentSplitter.split(document);
+
+        try (Session session = driver.session()) {
+            for (int i = 0; i < parentSegments.size(); i++) {
+                TextSegment parentSegment = parentSegments.get(i);
+                String parentId = /*document.id() +*/ "_p" + i;
+
+                // Store parent node
+                final Metadata metadata = document.metadata();
+                final Map<String, Object> metadataMap = metadata.toMap();
+                session.run("""
+                CREATE (:Parent {
+                    id: $id,
+                    title: $title,
+                    url: $url,
+                    text: $text
+                })
+            """, Map.of(
+                        "id", parentId,
+                        "title", metadataMap.getOrDefault("title", "Untitled"),
+                        "url", metadataMap.getOrDefault("url", ""),
+                        "text", parentSegment.text()
+                ));
+
+                // Convert back to Document to apply DocumentSplitter
+                Document parentDoc = Document.from(parentSegment.text(), metadata);
+
+                
+                // TODO --> org.neo4j.driver.exceptions.ClientException: Node(1) already exists with label `Child` and property `id` = 'doc-ai'
+                final String idProperty = embeddingStore.getIdProperty();
+                List<TextSegment> childSegments = childSplitter.split(parentDoc)
+                        .stream()
+                        .map(segment -> {
+                            final Metadata metadata1 = segment.metadata();
+                            final Object idMeta = metadata1.toMap().get(idProperty);
+//                            if (idMeta != null) {
+                            String value = parentId + idMeta;
+                            if (idMeta != null) {
+                                value += "_" + idMeta;
+                            }
+                            metadata1.put(idProperty, value);
+//                            }
+                            return segment;
+                        })
+                        .toList();
+
+                final List<Embedding> embeddings = embeddingModel.embedAll(childSegments).content();
+                embeddingStore.setAdditionalParams(Map.of("parentId", parentId));
+                embeddingStore.addAll(embeddings, childSegments);
+
+
+//                for (int j = 0; j < childSegments.size(); j++) {
+//                    TextSegment childSegment = childSegments.get(j);
+//                    String childId = parentId + "_c" + j;
+//
+//                    Embedding embedding = embeddingModel.embed(childSegment).content();
+//
+//                    // Store child node and link to parent
+//                    session.run(PARENT_QUERY, Map.of(
+//                            "parentId", parentId,
+//                            "childId", childId,
+//                            "text", childSegment.text(),
+//                            "embedding", embedding.vector()
+//                    ));
+//                }
+            }
+        }
+
+        // create vector index
+        try (var session = driver.session()) {
+
+//            Map<String, Object> params = Map.of(
+//                    "indexName",
+//                    vectorIndex,
+//                    "label",
+//                    this.label,
+//                    "embeddingProperty",
+//                    this.embeddingProperty,
+//                    "dimension",
+//                    this.dimension);
+            
+            final String createIndexQuery = String.format(
+                    CREATE_VECTOR_INDEX, embeddingStore.getIndexName(), 
+                    embeddingStore.getSanitizedLabel(), embeddingStore.getSanitizedEmbeddingProperty(), embeddingStore.getDimension());
+//                    CREATE_VECTOR_INDEX, vectorIndex, "Child", "embedding", embeddingDimension);
+            session.run(createIndexQuery);
+
+            session.run("CALL db.awaitIndexes($timeout)", Map.of("timeout", 20000))
+                    .consume();
+        }
+    }
+
+
+    @Override
+    public List<Content> retrieve(final Query query) {
+//        return List.of();
+//    }
+//
+//    public List<Content> retrieve(String query, int topK, double minScore) {
+        
+        Embedding queryEmbedding = embeddingModel.embed(query.text()).content();
+
+        // TODO - embeddingStore con retrievalQuery diversa?
+        try (Session session = driver.session()) {
+//            final String query1 = """
+//                        CALL db.index.vector.queryNodes($index, $k, $embedding)
+//                        YIELD node AS child, score
+//                        WHERE score >= $minScore
+//                        MATCH (child)<-[:HAS_CHILD]-(parent)
+//                        WITH parent, collect(child.text) AS chunks, max(score) AS score
+//                        RETURN parent.title + reduce(r = "", c in chunks | r + "\\n\\n" + c) AS text,
+//                               score,
+//                               {source: parent.url} AS metadata
+//                        ORDER BY score DESC
+//                        LIMIT $k
+//                    """;
+            final String query1 = """
+                        CALL db.index.vector.queryNodes($index, $k, $embedding)
+                        YIELD node AS child, score
+                        WHERE score >= $minScore
+                    """ + embeddingStore.getRetrievalQuery();
+            Result result = session.run(query1, Map.of(
+                    "index", embeddingStore.getIndexName(),
+                    "k", maxResults,
+                    "embedding", queryEmbedding.vector(),
+                    "minScore", minScore
+            ));
+
+            List<Content> results = new ArrayList<>();
+            while (result.hasNext()) {
+                Record record = result.next();
+                String mergedText = record.get("text").asString();
+                final Map<String, Object> metadata = record.get("metadata").asMap();
+
+                results.add(Content.from(
+                        TextSegment.from(mergedText, Metadata.from(metadata))//.withMetadata(metadata.asMap(Function.identity()))
+                ));
+            }
+
+            return results;
+        }
+    }
+
+}

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildRetriever.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildRetriever.java
@@ -1,0 +1,118 @@
+package dev.langchain4j.rag.content.retriever.neo4j;
+
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.content.retriever.ContentRetriever;
+import dev.langchain4j.rag.query.Metadata;
+import dev.langchain4j.rag.query.Query;
+import dev.langchain4j.store.embedding.EmbeddingMatch;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/*
+TODO
+def parent_document_retrieval(
+    query: str, client: Milvus | Chroma, window_size: int = 4
+):
+    top_1 = client.similarity_search(query=query, k=1)[0]
+    doc_id = top_1.metadata["document_id"]
+    seq_num = top_1.metadata["sequence_number"]
+    ids_window = [seq_num + i for i in range(-window_size, window_size, 1)]
+    # ...
+ */
+public class ParentChildRetriever implements ContentRetriever {
+
+    /*
+    retriever = ParentDocumentRetriever(
+    vectorstore=vectorstore,
+    docstore=store,
+    child_splitter=child_splitter,
+    parent_splitter=parent_splitter,
+)
+     */
+    
+    private final EmbeddingModel embeddingModel;
+    private final Neo4jEmbeddingStore embeddingStore;
+    private final Neo4jGraph graph;
+
+    private final int maxResults;
+    private final double minScore;
+
+    // TODO - get Neo4jGraph from Neo4jEmbeddingStore
+    public ParentChildRetriever(EmbeddingModel embeddingModel, Neo4jEmbeddingStore embeddingStore, Neo4jGraph graph,
+                                int maxResults,
+                                double minScore) {
+        this.embeddingModel = embeddingModel;
+        this.embeddingStore = embeddingStore;
+        this.graph = graph;
+        this.maxResults = maxResults;
+        this.minScore = minScore;
+    }
+
+    @Override
+    public List<Content> retrieve(Query query) {
+        // Step 1: Embed the user query
+        // TODO - METADATA?
+        Embedding queryEmbedding = embeddingModel.embed(query.text()).content();
+
+        // Step 2: Perform vector similarity search on child embeddings
+        final EmbeddingSearchRequest request = EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .maxResults(maxResults)
+                .build();
+        final List<EmbeddingMatch<TextSegment>> matches = embeddingStore.search(request).matches();
+
+        // Step 3: Filter by minScore and collect child IDs
+        // todo - needed?
+        List<String> childIds = new ArrayList<>();
+
+        for (EmbeddingMatch<TextSegment> match : matches) {
+            if (match.score() >= minScore) {
+                String id = match.embeddingId(); 
+                        // (String) match.embedded().metadata().getString("id"); // TODO - assumes ID is in metadata
+                if (id != null) {
+                    childIds.add(id);
+                }
+                
+//                childIds.add(match.embedded().metadata().get("id").toString()); // Assuming "id" is in metadata
+            }
+        }
+        
+        if (childIds.isEmpty()) return List.of();
+         
+        
+        // todo --> https://github.com/damiangilgonzalez1995/AdvancedRetrievalRags/blob/main/2_parent_document_retriever.ipynb
+        // TODO --> https://graphrag.com/reference/graphrag/parent-child-retriever/
+        // TODO --> https://blog.langchain.dev/implementing-advanced-retrieval-rag-strategies-with-neo4j/
+        // TODO - https://www.youtube.com/watch?v=wSi0fxkH6e0
+        // TODO: https://towardsdatascience.com/langchains-parent-document-retriever-revisited-1fca8791f5a0/
+//        if (matches.)
+
+
+        // Step 4: Query parent documents from Neo4j
+        List<Content> parentContents = new ArrayList<>();
+        try (Session session = graph.driver.session()) {
+            String cypherQuery = "MATCH (child)<-[:HAS_CHILD]-(parent) " +
+                    "WHERE child.id IN $childIds " +
+                    "RETURN parent.text AS text, parent AS metadata";
+            Result result = session.run(cypherQuery, Map.of("childIds", childIds));
+            while (result.hasNext()) {
+                Record record = result.next();
+                final TextSegment text = TextSegment.from(record.get("text").asString());
+//                Map<String, Object> metadata = record.get("metadata").asMap();
+                // TODO - HANDLE MAP.OF
+                parentContents.add(Content.from(text, Map.of()));
+            }
+        }
+        return parentContents;
+    }
+}

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/SummaryRetriever.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/main/java/dev/langchain4j/rag/content/retriever/neo4j/SummaryRetriever.java
@@ -1,0 +1,91 @@
+package dev.langchain4j.rag.content.retriever.neo4j;
+
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import org.neo4j.driver.Driver;
+
+import java.util.Map;
+
+public class SummaryRetriever extends Neo4jEmbeddingRetriever {
+    public final static String DEFAULT_RETRIEVAL = """
+            MATCH (node)<-[:HAS_SUMMARY]-(parent)
+            WITH parent, max(score) AS score, node // deduplicate parents
+            RETURN parent.text AS text, score, properties(node) AS metadata
+            ORDER BY score DESC
+            LIMIT $maxResults""";
+
+    public final static String SYSTEM_PROMPT = """
+            You are generating concise and accurate summaries based on the information found in the text.
+            """;
+
+    public final static String USER_PROMPT = """
+            Generate a summary of the following input:
+            {{input}}
+            
+            Summary:
+            """; 
+            
+    
+    /*
+        MERGE (p:Parent {id: $parent_id})
+    SET p.text = $parent_text
+    WITH p
+    CALL db.create.setVectorProperty(p, 'embedding', $parent_embedding)
+    YIELD node
+    WITH p 
+    UNWIND $children AS child
+    MERGE (c:Child {id: child.id})
+    SET c.text = child.text
+    MERGE (c)<-[:HAS_CHILD]-(p)
+    WITH c, child
+    CALL db.create.setVectorProperty(c, 'embedding', child.embedding)
+    YIELD node
+    RETURN count(*)
+     */
+//    public static final String PARENT_QUERY =
+//            """
+//                        UNWIND $rows AS question
+//                        MERGE (p:Parent {id: $parentId})
+//                        // SET p.text = $parent_text
+//                        WITH p
+//                        CALL db.create.setVectorProperty(p, 'embedding', $parent_embedding)
+//                        YIELD node
+//                        WITH p\s
+//                        UNWIND $children AS child
+//                        MERGE (c:Child {id: child.id})
+//                        SET c.text = child.text
+//                        MERGE (c)<-[:HAS_CHILD]-(p)
+//                        WITH c, child
+//                        CALL db.create.setVectorProperty(c, 'embedding', child.embedding)
+//                        YIELD node
+//                        RETURN count(*)
+//                    """;
+
+    public static final String PARENT_QUERY =
+
+            """
+                UNWIND $rows AS row
+                MATCH (p:Parent {parentId: $parentId})
+                CREATE (p)-[:HAS_SUMMARY]->(u:%1$s {%2$s: row.%2$s})
+                SET u += row.%3$s
+                WITH row, u
+                CALL db.create.setNodeVectorProperty(u, $embeddingProperty, row.%4$s)
+                RETURN count(*)""";
+    
+    public SummaryRetriever(final EmbeddingModel embeddingModel, final Driver driver, final int maxResults, final double minScore, final Neo4jEmbeddingStore embeddingStore, final ChatLanguageModel chatModel) {
+            super(embeddingModel, driver, maxResults, minScore, "CREATE (:Parent $metadata)", Map.of(), embeddingStore, chatModel, SYSTEM_PROMPT, USER_PROMPT, null, null);
+    }
+
+    @Override
+    public Neo4jEmbeddingStore getDefaultEmbeddingStore(final Driver driver) {
+        return Neo4jEmbeddingStore.builder()
+                .driver(driver)
+                .retrievalQuery(DEFAULT_RETRIEVAL)
+                .entityCreationQuery(PARENT_QUERY)
+                .label("Summary")
+                .indexName("summary_embedding_index")
+                .dimension(384)
+                .build();
+    }
+}

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4JText2CypherRetrieverIT.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4JText2CypherRetrieverIT.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
-class Neo4JText2CypherRetrieverIT extends Neo4jText2CypherRetrieverBaseTest {
+class Neo4JText2CypherRetrieverIT extends Neo4jRetrieverBaseTest {
 
     @Test
     void shouldRetrieveContentWhenQueryIsValidAndOpenAiChatModelIsUsed() {

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4JText2CypherRetrieverIT.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4JText2CypherRetrieverIT.java
@@ -10,10 +10,18 @@ import dev.langchain4j.rag.query.Query;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.neo4j.driver.Session;
 
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
 class Neo4JText2CypherRetrieverIT extends Neo4jRetrieverBaseTest {
 
+    @Override
+    public void initDb() {
+        try (Session session = driver.session()) {
+            session.run("CREATE (book:Book {title: 'Dune'})<-[:WROTE]-(author:Person {name: 'Frank Herbert'})");
+        }
+    }
+    
     @Test
     void shouldRetrieveContentWhenQueryIsValidAndOpenAiChatModelIsUsed() {
 

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4JText2CypherRetrieverTest.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4JText2CypherRetrieverTest.java
@@ -13,12 +13,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.neo4j.driver.Session;
 
 @ExtendWith(MockitoExtension.class)
 public class Neo4JText2CypherRetrieverTest extends Neo4jRetrieverBaseTest {
 
     private Neo4jText2CypherRetriever retriever;
-
+    
+    @Override
+    public void initDb() {
+        try (Session session = driver.session()) {
+            session.run("CREATE (book:Book {title: 'Dune'})<-[:WROTE]-(author:Person {name: 'Frank Herbert'})");
+        }
+    }
+    
+    // TODO - mock tests in retriever
     @Mock
     private ChatLanguageModel chatLanguageModel;
 

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4JText2CypherRetrieverTest.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4JText2CypherRetrieverTest.java
@@ -15,7 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class Neo4JText2CypherRetrieverTest extends Neo4jText2CypherRetrieverBaseTest {
+public class Neo4JText2CypherRetrieverTest extends Neo4jRetrieverBaseTest {
 
     private Neo4jText2CypherRetriever retriever;
 

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jRetrieverBaseTest.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/Neo4jRetrieverBaseTest.java
@@ -11,7 +11,7 @@ import org.neo4j.driver.Session;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Container;
 
-public class Neo4jText2CypherRetrieverBaseTest {
+public class Neo4jRetrieverBaseTest {
 
     protected static final String NEO4J_VERSION = System.getProperty("neo4jVersion", "5.26");
 

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildRetrieverTest.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildRetrieverTest.java
@@ -1,0 +1,367 @@
+package dev.langchain4j.rag.content.retriever.neo4j;
+
+import dev.langchain4j.community.store.embedding.neo4j.Neo4jEmbeddingStore;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.splitter.DocumentByRegexSplitter;
+import dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+//import dev.langchain4j.model.embedding.onnx.allminilml6v2.AllMiniLmL6V2EmbeddingModel;
+//import dev.langchain4j.store.embedding.neo4j.Neo4jEmbeddingStore;
+//import dev.langchain4j.graph.Neo4jGraph;
+import dev.langchain4j.model.embedding.onnx.allminilml6v2q.AllMiniLmL6V2QuantizedEmbeddingModel;
+import dev.langchain4j.rag.content.Content;
+import dev.langchain4j.rag.query.Query;
+import org.junit.jupiter.api.*;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
+import org.testcontainers.containers.Neo4jContainer;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static dev.langchain4j.rag.content.retriever.neo4j.Neo4jRetrieverBaseTest.NEO4J_VERSION;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ParentChildRetrieverTest {
+
+    private static Neo4jContainer<?> neo4jContainer;
+    private static Neo4jEmbeddingStore embeddingStore;
+    private static Neo4jGraph graph;
+    private static EmbeddingModel embeddingModel;
+    private static Driver driver;
+    private static ParentChildRetriever retriever;
+
+
+    @BeforeAll
+    public static void setUp() {
+        // Start Neo4j Testcontainer
+        neo4jContainer = new Neo4jContainer<>("neo4j:" + NEO4J_VERSION)
+                .withPlugins("apoc")
+                .withoutAuthentication(); // Disable authentication for testing
+        //.withAdminPassword("test1234"); /
+        neo4jContainer.start();
+
+        driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.none());
+
+        // Initialize Neo4jEmbeddingStore
+        embeddingStore = Neo4jEmbeddingStore.builder()
+                .driver(driver)
+                .databaseName("neo4j")
+                .dimension(384)
+                .build();
+
+        // Initialize Neo4jGraph
+        graph = Neo4jGraph.builder()
+                .driver(driver)
+                .build();
+
+        // Initialize Embedding Model
+        embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+
+        retriever = new ParentChildRetriever(
+                embeddingModel,
+                embeddingStore,
+                graph,
+                5,
+                0.6
+        );
+        
+        // seedTestData();
+    }
+    
+    // TODO --> https://medium.com/data-science/langchains-parent-document-retriever-revisited-1fca8791f5a0
+    
+    /*
+    - Instead of indexing entire documents, data is divided into smaller chunks, referred to as Parent and Child documents.
+
+    - Child documents are indexed for better representation of specific concepts, while parent documents are retrieved to ensure context retention.
+     */
+
+
+    @AfterEach
+    void afterEach() {
+        try (Session session = driver.session()) {
+            session.run("MATCH (n) DETACH DELETE n");
+        }
+//        graph.close();
+//        driver.close();
+    }
+
+
+    @Test
+    public void testParentChildRetriever_withDocumentByRegexSplitter() {
+        EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+        String vectorIndex = "child_embedding_index";
+        int embeddingDimensions = 384;
+
+        ParentChildGraphRetriever2 retriever = new ParentChildGraphRetriever2(
+                embeddingModel, driver, vectorIndex, embeddingDimensions
+        );
+
+        // Parent splitter splits on paragraphs (double newlines)
+        final String expectedQuery = "\\n\\n";
+        int maxSegmentSize = 250;
+        DocumentSplitter parentSplitter = new DocumentByRegexSplitter(expectedQuery, expectedQuery, maxSegmentSize, 0);
+
+        // Child splitter splits on periods (sentences)
+        final String expectedQuery1 = "\\. ";
+        DocumentSplitter childSplitter = new DocumentByRegexSplitter(expectedQuery1, expectedQuery, maxSegmentSize, 0);
+
+        Document doc = Document.from(
+                """
+                Artificial Intelligence (AI) is a field of computer science. It focuses on creating intelligent agents capable of performing tasks that require human intelligence.
+        
+                Machine Learning (ML) is a subset of AI. It uses data to learn patterns and make predictions. Deep Learning is a specialized form of ML based on neural networks.
+                """,
+                Metadata.from(Map.of("title", "AI Overview", "url", "https://example.com/ai", "id", "doc-ai"))
+        );
+
+        // Index the document into Neo4j as parent-child nodes
+        retriever.index(doc, parentSplitter, childSplitter);
+
+        // Query and validate results
+        List<Content> results = retriever.retrieve("What is Machine Learning?", 3, 0.5);
+
+        assertFalse(results.isEmpty(), "Should retrieve at least one parent document");
+
+        Content result = results.get(0);
+        System.out.println("Retrieved Text:\n" + result.textSegment().text());
+        System.out.println("Metadata: " + result.textSegment().metadata());
+
+        assertTrue(result.textSegment().text().toLowerCase().contains("machine learning"));
+        assertEquals("https://example.com/ai", result.textSegment().metadata().getString("source"));
+    }
+    
+    
+//import dev.langchain4j.data.document.splitter.DocumentBySentenceSplitter;
+//import dev.langchain4j.data.document.splitter.DocumentSplitter;
+
+    @Test
+    public void testParentChildRetriever_withDocumentBySentenceSplitter() {
+        EmbeddingModel embeddingModel = new AllMiniLmL6V2QuantizedEmbeddingModel();
+        String vectorIndex = "child_embedding_index_sentence";
+        int embeddingDimensions = 384;
+
+        ParentChildGraphRetriever2 retriever = new ParentChildGraphRetriever2(
+                embeddingModel, driver, vectorIndex, embeddingDimensions
+        );
+
+        int maxSegmentSize = 250;
+
+        // Parent splitter: splits on paragraphs (double newlines)
+        final String expectedQuery = "\\n\\n";
+        DocumentSplitter parentSplitter = new DocumentByRegexSplitter(expectedQuery, expectedQuery, maxSegmentSize, 0);
+
+        // Child splitter: splits into sentences using OpenNLP
+        DocumentSplitter childSplitter = new DocumentBySentenceSplitter(maxSegmentSize, 0);
+
+        Document doc = Document.from(
+                """
+                Artificial Intelligence (AI) is transforming various industries. It enables machines to learn from data and make decisions.
+        
+                Machine Learning (ML) is a subset of AI. It focuses on developing algorithms that allow computers to learn from and make predictions based on data.
+                """,
+                Metadata.from(Map.of("title", "AI and ML Overview", "url", "https://example.com/ai-ml", "id", "doc-ai-ml"))
+        );
+
+        retriever.index(doc, parentSplitter, childSplitter);
+
+        List<Content> results = retriever.retrieve("What is Machine Learning?", 3, 0.5);
+
+        assertFalse(results.isEmpty(), "Should retrieve at least one parent document");
+        assertTrue(results.get(0).textSegment().text().toLowerCase().contains("machine learning"));
+        assertEquals("https://example.com/ai-ml", results.get(0).textSegment().metadata().getString("source"));
+    }
+
+
+
+    static void seedTestData() {
+        try (var session = driver.session()) {
+            session.run("MATCH (n) DETACH DELETE n");
+
+            // Create parent and child
+            session.run("""
+                CREATE (parent:Document {id: 'parent-1', text: 'This is the parent doc.', source: 'test'})
+                CREATE (child:Chunk {id: 'child-1', text: 'This is a detailed chunk about embeddings.', chunk: 1})
+                CREATE (parent)-[:HAS_CHILD]->(child)
+            """);
+
+            // Embed and store child embedding
+            Embedding embedding = embeddingModel.embed("This is a detailed chunk about embeddings.").content();
+            TextSegment segment = new TextSegment("This is a detailed chunk about embeddings.",
+                    Metadata.from(Map.of("id", "child-1"))
+            );
+
+            embeddingStore.add(embedding, segment);
+        }
+    }
+
+
+    static void seedTestData1() {
+        try (var session = driver.session()) {
+            session.run("MATCH (n) DETACH DELETE n");
+
+            session.run("""
+                CREATE (p1:Document {id: 'p1', text: 'Parent about machine learning', source: 'ml'})
+                CREATE (p2:Document {id: 'p2', text: 'Parent about cooking', source: 'food'})
+                CREATE (p3:Document {id: 'p3', text: 'Parent about quantum physics', source: 'science'})
+
+                CREATE (c1:Chunk {id: 'c1', text: 'Gradient descent and backpropagation algorithms', chunk: 1})
+                CREATE (c2:Chunk {id: 'c2', text: 'Spaghetti carbonara and Italian dishes', chunk: 2})
+                CREATE (c3:Chunk {id: 'c3', text: 'Quantum entanglement and uncertainty principles', chunk: 3})
+
+                CREATE (p1)-[:HAS_CHILD]->(c1)
+                CREATE (p2)-[:HAS_CHILD]->(c2)
+                CREATE (p3)-[:HAS_CHILD]->(c3)
+            """);
+
+            // Embed and store all children
+            addChunkEmbedding("Gradient descent and backpropagation algorithms", "c1");
+            addChunkEmbedding("Spaghetti carbonara and Italian dishes", "c2");
+            addChunkEmbedding("Quantum entanglement and uncertainty principles", "c3");
+        }
+    }
+
+
+
+    static void addChunkEmbedding(String text, String id) {
+        Embedding embedding = embeddingModel.embed(text).content();
+        TextSegment segment = new TextSegment(text, Metadata.from(Map.of("id", id)));
+        embeddingStore.add(embedding, segment);
+    }
+
+    @Test
+    void testRetrieverReturnsOnlyRelevantParent() {
+        seedTestData1();
+        // Act
+        List<Content> results = retriever.retrieve(new Query("Tell me about training neural networks"));
+
+        // Assert
+        assertEquals(1, results.size());
+        Content parent = results.get(0);
+
+        assertTrue(parent.textSegment().text().contains("machine learning"));
+        assertEquals("ml", parent.metadata().get("source"));
+    }
+
+    @Test
+    void testRetrieverReturnsNothingForUnrelatedQuery() {
+        seedTestData1();
+        List<Content> results = retriever.retrieve(new Query("Soccer match results and player stats"));
+
+        assertTrue(results.isEmpty(), "No relevant parents should match soccer topics");
+    }
+
+    @Test
+    void testRetrieverReturnsMultipleParents() {
+        seedTestData1();
+        List<Content> results = retriever.retrieve(new Query("Tell me about quantum mechanics and cooking"));
+
+        Set<String> sources = new HashSet<>();
+        for (Content c : results) {
+            sources.add((String) c.metadata().get("source"));
+        }
+
+        assertTrue(sources.contains("food"));
+        assertTrue(sources.contains("science"));
+    }
+    
+    
+
+    @Test
+    void retrievesParentGivenQueryAboutEmbeddings() {
+//        final ParentChildRetriever retriever = new ParentChildRetriever(
+//                embeddingModel,
+//                embeddingStore,
+//                graph,
+//                5,
+//                0.0
+//        );
+
+        seedTestData();
+        List<Content> result = retriever.retrieve(new Query("Tell me about embeddings"));
+
+        assertFalse(result.isEmpty());
+        Content content = result.get(0);
+        assertTrue(content.textSegment().text().contains("parent doc"));
+        assertEquals("test", content.metadata().get("source"));
+    }
+
+    @Test
+    public void testParentChildRetrievalWithMultipleRelationships() {
+        // Step 1: Document Chunking
+        String parentText1 = "Artificial Intelligence is a branch of computer science.";
+        String childText1 = "AI is a branch.";
+
+        String parentText2 = "Machine Learning is a subset of Artificial Intelligence.";
+        String childText2 = "ML is a subset of AI.";
+
+        // Step 2: Embedding Storage
+        TextSegment childSegment1 = TextSegment.from(childText1);
+        Embedding childEmbedding1 = embeddingModel.embed(childSegment1).content();
+        String childId1 = embeddingStore.add(childEmbedding1, childSegment1);
+
+        TextSegment childSegment2 = TextSegment.from(childText2);
+        Embedding childEmbedding2 = embeddingModel.embed(childSegment2).content();
+        String childId2 = embeddingStore.add(childEmbedding2, childSegment2);
+
+        // Step 3: Graph Relationships
+        try (Session session = driver.session()) {
+            String createParentChildQuery = "CREATE (p:Parent {text: $parentText})-[:HAS_CHILD]->(c:Child {id: $childId, text: $childText})";
+            session.run(createParentChildQuery, Map.of("parentText", parentText1, "childId", childId1, "childText", childText1));
+            session.run(createParentChildQuery, Map.of("parentText", parentText2, "childId", childId2, "childText", childText2));
+        }
+
+        // Step 4: Retrieval Testing
+        ParentChildRetriever retriever = new ParentChildRetriever(embeddingModel, embeddingStore, graph, 10, 0.0);
+        Query query = new Query("What is AI?");
+        List<Content> results = retriever.retrieve(query);
+
+        // Verify that the correct parent documents are retrieved
+        assertEquals(2, results.size());
+        assertTrue(results.stream().anyMatch(content -> content.textSegment().text().equals(parentText1)));
+        assertTrue(results.stream().anyMatch(content -> content.textSegment().text().equals(parentText2)));
+
+        // Verify that the similarity scores are above a threshold
+        float threshold = 0.8f;
+        for (Content content : results) {
+            System.out.println("content = " + content);
+        }
+//            assertTrue(content() >= threshold, "Similarity score is below threshold");
+    }
+
+    @Test
+    public void testParentChildRetrievalWithNoMatches() {
+        seedTestData();
+        // Step 1: Document Chunking
+        String parentText = "Quantum Computing is a field of computing focused on quantum mechanics.";
+        String childText = "Quantum Computing uses qubits.";
+
+        // Step 2: Embedding Storage
+        TextSegment childSegment = TextSegment.from(childText);
+        Embedding childEmbedding = embeddingModel.embed(childSegment).content();
+        String childId = embeddingStore.add(childEmbedding, childSegment);
+
+        // Step 3: Graph Relationships
+        try (Session session = driver.session()) {
+            String createParentChildQuery = "CREATE (p:Parent {text: $parentText})-[:HAS_CHILD]->(c:Child {id: $childId, text: $childText})";
+            session.run(createParentChildQuery, Map.of("parentText", parentText, "childId", childId, "childText", childText));
+        }
+
+        // Step 4: Retrieval Testing
+        ParentChildRetriever retriever = new ParentChildRetriever(embeddingModel, embeddingStore, graph, 10, 0.0);
+        Query query = new Query("What is classical computing?");
+        List<Content> results = retriever.retrieve(query);
+
+        // Verify that no parent documents are retrieved
+        assertTrue(results.isEmpty(), "Expected no results but found some");
+    }
+}

--- a/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildRetrieverTest2.java
+++ b/content-retrievers/langchain4j-community-neo4j-retriever/src/test/java/dev/langchain4j/rag/content/retriever/neo4j/ParentChildRetrieverTest2.java
@@ -20,24 +20,16 @@ import dev.langchain4j.rag.content.Content;
 import dev.langchain4j.rag.query.Query;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.neo4j.driver.AuthTokens;
-import org.neo4j.driver.Driver;
-import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
-import org.testcontainers.containers.Neo4jContainer;
 
-import java.time.Duration;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
 import static dev.langchain4j.rag.content.retriever.neo4j.Neo4jEmbeddingRetriever.DEFAULT_PROMPT_ANSWER;
-import static dev.langchain4j.rag.content.retriever.neo4j.Neo4jRetrieverBaseTest.NEO4J_VERSION;
 import static dev.langchain4j.rag.content.retriever.neo4j.ParentChildGraphRetriever2.DEFAULT_RETRIEVAL;
 import static dev.langchain4j.rag.content.retriever.neo4j.ParentChildGraphRetriever2.PARENT_QUERY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 // OPENAI_API_KEY=demo;OPENAI_BASE_URL=http://langchain4j.dev/demo/openai/v1
 @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
-public class ParentChildRetrieverTest extends Neo4jRetrieverBaseTest {
+public class ParentChildRetrieverTest2 extends Neo4jRetrieverBaseTest {
 
     ChatLanguageModel chatModel = OpenAiChatModel.builder()
             .baseUrl(System.getenv("OPENAI_BASE_URL"))
@@ -688,8 +680,6 @@ public class ParentChildRetrieverTest extends Neo4jRetrieverBaseTest {
 //        assertEquals("test", content.metadata().get("source"));
 //    }
 
-    
-    // TODO - change with correctParentChildRetriever and check
     @Test
     public void testParentChildRetrievalWithMultipleRelationships() {
         // Step 1: Document Chunking


### PR DESCRIPTION
References:

    // TODO https://chatgpt.com/c/67ff6a72-5fe0-800c-9c12-c50ec8d5ee35
    // todo --> creare un fromLLM

- https://neo4j.com/labs/genai-ecosystem/langchain/#_cypherqachain
- https://blog.langchain.dev/implementing-advanced-retrieval-rag-strategies-with-neo4j/
- https://github.com/neo4j-examples/rag-demo/tree/main/rag_demo
- https://github.com/neo4j-examples/rag-demo/blob/main/rag_demo/vector_chain.py

TODO - WAITING FOR cypher-dsl PR

TODO, CHECK IF TO ADD:
- https://graphrag.com/reference/graphrag/basic-retriever/
- https://github.com/neo4j-examples/rag-demo/blob/main/rag_demo/vector_chain.py
- https://api.python.langchain.com/en/latest/retrievers/langchain.retrievers.multi_vector.MultiVectorRetriever.html#langchain.retrievers.multi_vector.MultiVectorRetriever

NOTE:
in this links it uses the `from_chain_type`, but we create a method `fromLLM` since [here](https://python.langchain.com/docs/integrations/graphs/neo4j_cypher/) use the from_llm one
- https://www.youtube.com/watch?v=wSi0fxkH6e0


---

EVALUATE IN FUTURE:
https://api.python.langchain.com/en/latest/langchain_api_reference.html#module-langchain.retrievers


many of the retrievers were deleted/moved from langchain-ai, retrieved via old tags